### PR TITLE
Resolve deprecations

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class IndexController extends Controller {
+  @service router;
   @service store;
   @tracked werkingsgebiedId;
   @tracked bestuurseenheidId;
@@ -42,6 +43,6 @@ export default class IndexController extends Controller {
   @action
   viewBestuursorgaan(bestuursorgaanId) {
     this.bestuursorgaanId = bestuursorgaanId;
-    this.transitionToRoute('bestuursorgaan.subject', bestuursorgaanId);
+    this.router.transitionTo('bestuursorgaan.subject', bestuursorgaanId);
   }
 }

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -2,8 +2,10 @@ import { task, timeout } from 'ember-concurrency';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class IndexController extends Controller {
+  @service store;
   @tracked werkingsgebiedId;
   @tracked bestuurseenheidId;
   @tracked bestuursorgaanId;

--- a/app/routes/bestuursorgaan/subject.js
+++ b/app/routes/bestuursorgaan/subject.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class BestuursorgaanSubjectRoute extends Route {
+  @service store;
+
   model(params) {
     return this.store.findRecord('bestuursorgaan', params.bestuursorgaan_id, {
       include: 'is-tijdsspecialisatie-van,heeft-tijdsspecialisaties,bevat',

--- a/app/routes/bestuursorgaan/subject/index.js
+++ b/app/routes/bestuursorgaan/subject/index.js
@@ -1,11 +1,14 @@
 /* eslint-disable ember/no-mixins */
 import { debug } from '@ember/debug';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
 
 export default class BestuursorgaanSubjectIndexRoute extends Route.extend(
   DataTableRouteMixin
 ) {
+  @service store;
+
   modelName = 'mandataris';
 
   async getLastBestuursorgaan(bestuursorgaan) {

--- a/app/routes/bestuursorgaan/subject/index.js
+++ b/app/routes/bestuursorgaan/subject/index.js
@@ -7,6 +7,7 @@ import DataTableRouteMixin from 'ember-data-table/mixins/route';
 export default class BestuursorgaanSubjectIndexRoute extends Route.extend(
   DataTableRouteMixin
 ) {
+  @service router;
   @service store;
 
   modelName = 'mandataris';
@@ -24,7 +25,7 @@ export default class BestuursorgaanSubjectIndexRoute extends Route.extend(
       // niet-tijdsgebonden bestuursorgaan
       debug('Redirect to most recent time period.');
       let lastOrgaan = await this.getLastBestuursorgaan(bestuursorgaan);
-      this.transitionTo('bestuursorgaan.subject.index', lastOrgaan.get('id'));
+      this.router.transitionTo('bestuursorgaan.subject.index', lastOrgaan.id);
     }
   }
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
+import { inject as service } from '@ember/service';
 
 export default class IndexRoute extends Route {
+  @service store;
+
   queryParams = {
     werkingsgebiedId: { refreshModel: true },
     bestuurseenheidId: { refreshModel: true },

--- a/app/routes/persoon/subject.js
+++ b/app/routes/persoon/subject.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class PersoonSubjectRoute extends Route {
+  @service store;
+
   model(params) {
     return this.store.findRecord('persoon', params.persoon_id);
   }

--- a/app/routes/persoon/subject/index.js
+++ b/app/routes/persoon/subject/index.js
@@ -1,10 +1,13 @@
-/* eslint-disable ember/no-mixins */
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+/* eslint-disable ember/no-mixins */
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
 
 export default class PersoonSubjectIndexRoute extends Route.extend(
   DataTableRouteMixin
 ) {
+  @service store;
+
   modelName = 'mandataris';
   mergeQueryOptions(params) {
     const { persoon_id } = this.paramsFor('persoon.subject');

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -17,13 +17,13 @@
         <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>
         <ul class="au-c-list-horizontal">
           <li class="au-c-list-horizontal__item">
-            <AuLink @linkRoute="legaal.disclaimer" @skin="secondary">Disclaimer</AuLink>
+            <AuLink @route="legaal.disclaimer" @skin="secondary">Disclaimer</AuLink>
           </li>
           <li class="au-c-list-horizontal__item">
-            <AuLink @linkRoute="legaal.cookieverklaring" @skin="secondary">Cookieverklaring</AuLink>
+            <AuLink @route="legaal.cookieverklaring" @skin="secondary">Cookieverklaring</AuLink>
           </li>
           <li class="au-c-list-horizontal__item">
-            <AuLink @linkRoute="legaal.toegankelijkheidsverklaring" @skin="secondary">Toegankelijkheid</AuLink>
+            <AuLink @route="legaal.toegankelijkheidsverklaring" @skin="secondary">Toegankelijkheid</AuLink>
           </li>
         </ul>
       </AuContent>

--- a/app/templates/bestuursorgaan/subject.hbs
+++ b/app/templates/bestuursorgaan/subject.hbs
@@ -2,7 +2,7 @@
 <div data-tabs-responsive-label="Navigatie">
   <div class="au-o-region-small au-o-region--alt">
     <div class="au-o-box">
-      <AuLink @linkRoute="index" class="au-u-margin-bottom">
+      <AuLink @route="index" class="au-u-margin-bottom">
         <AuIcon @icon="nav-left" @alignment="left" />
         Terug naar zoeken
       </AuLink>

--- a/app/templates/persoon/subject.hbs
+++ b/app/templates/persoon/subject.hbs
@@ -3,7 +3,7 @@
   <div data-tabs-responsive-label="Navigatie">
     <div class="au-o-region-small au-o-region--alt">
       <div class="au-o-box">
-        <AuLink @linkRoute="index" class="au-u-margin-bottom">
+        <AuLink @route="index" class="au-u-margin-bottom">
           <AuIcon @icon="nav-left" @alignment="left" />
           Terug naar zoeken
         </AuLink>


### PR DESCRIPTION
This resolves some Ember v3 and Appuniversum v1 deprecations. The remaining deprecations will be resolved by updating / removing dependencies.

Remaining deprecations:
- some `this.` deprecations coming from the wu-radio-button component (which will be replaced with an Appuniversum variant)
- some ember-modifier deprecations, which will be resolved by dependency updates
- some deprecations caused by ember-cli-babel v6 usage in some addons