### PR TITLE
[DL-6037] Switch to the `redpencil/fastboot-app-server` image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ COPY . .
 RUN npm run build
 
 
-FROM cecemel/ember-fastboot-proxy-service:0.6.0
-
-ENV STATIC_FOLDERS_REGEX "^/(assets|font|files|sitemap.xml|@appuniversum)/"
+# TODO: replace this with the tagged version when it's released
+# https://github.com/redpencilio/fastboot-app-server-service/pull/9
+FROM redpencil/fastboot-app-server:feature-node-20
 
 COPY --from=builder /app/dist /app

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,6 +1,17 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import { service } from '@ember/service';
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
+  @service fastboot;
+
+  constructor() {
+    super(...arguments);
+
+    if (this.fastboot.isFastBoot && window.BACKEND_URL) {
+      this.host = window.BACKEND_URL;
+    }
+  }
+
   ajax(url, method) {
     if (method === 'POST') return super.ajax(...arguments);
 


### PR DESCRIPTION
This service replaced the `cecemel/ember-fastboot-proxy-service` and ships with newer node versions. 

Breaking since it requires changes in the dispatcher configuration.