### PR TITLE
[DL-6607] Add wrap class around AuLink button

### DIFF
--- a/app/components/bestuursorgaan-search-wizard.hbs
+++ b/app/components/bestuursorgaan-search-wizard.hbs
@@ -91,7 +91,7 @@
                     @iconAlignment="right"
                     @size="large"
                     @width="block"
-                    class="au-c-button--large" {{!TODO: remove this once the link component supports a "large" button style}}
+                    class="au-c-button--large au-c-button--wrap" {{!TODO: remove this once the link component supports a "large" button style}}
                   >
                     Kies {{orgaan.classificatie.label}}
                   </AuLink>


### PR DESCRIPTION
# Context

[DL-6607]

![image](https://github.com/user-attachments/assets/ee2eaed3-b781-48ca-8769-58583b518e18)

The text was growing out of the `AuLink` button-styled component. Adding the `au-c-button--wrap` is a bit of a hacky solution, we might want to rethink how we display them in the future.